### PR TITLE
URL Cleanup

### DIFF
--- a/spring-security-portlet/src/main/java/org/springframework/security/extensions/portlet/PortletProcessingInterceptor.java
+++ b/spring-security-portlet/src/main/java/org/springframework/security/extensions/portlet/PortletProcessingInterceptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-security-portlet/src/main/java/org/springframework/security/extensions/portlet/PortletSessionContextIntegrationInterceptor.java
+++ b/spring-security-portlet/src/main/java/org/springframework/security/extensions/portlet/PortletSessionContextIntegrationInterceptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-security-portlet/src/test/java/org/springframework/security/extensions/portlet/PortletProcessingInterceptorTests.java
+++ b/spring-security-portlet/src/test/java/org/springframework/security/extensions/portlet/PortletProcessingInterceptorTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-security-portlet/src/test/java/org/springframework/security/extensions/portlet/PortletSessionContextIntegrationInterceptorTests.java
+++ b/spring-security-portlet/src/test/java/org/springframework/security/extensions/portlet/PortletSessionContextIntegrationInterceptorTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-security-portlet/src/test/java/org/springframework/security/extensions/portlet/PortletTestUtils.java
+++ b/spring-security-portlet/src/test/java/org/springframework/security/extensions/portlet/PortletTestUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://www.apache.org/licenses/LICENSE-2.0 with 5 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).